### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/shared/home-manager/home.nix
+++ b/shared/home-manager/home.nix
@@ -44,7 +44,7 @@
   home = {
     username = "sean";
     homeDirectory = "/home/sean";
-    # https://nixos.wiki/wiki/FAQ/When_do_I_update_stateVersion
+    # https://wiki.nixos.org/wiki/FAQ/When_do_I_update_stateVersion
     sessionVariables = {
         VISUAL = "kak";
     };


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️